### PR TITLE
Update binary_search.py

### DIFF
--- a/Arrays-searching/src/binary_search/binary_search.py
+++ b/Arrays-searching/src/binary_search/binary_search.py
@@ -19,7 +19,7 @@ def binary_search(sorted_array, search_key):
         last_index = len(sorted_array) - 1
         found = False
         while first_index <= last_index and not found:
-            mid = (first_index + last_index) / 2
+            mid = (first_index + last_index) // 2
             if sorted_array[mid] == search_key:
                 found = True
                 break


### PR DESCRIPTION


```
# Description

Changed (first_index + last_index) / 2
to (first_index + last_index) // 2

(in previous code) if length of sorted array is 6, then first_index = 0 and last_index = 5, mid = 2.5
so accessing sorted_array[2.5] will cause error.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
```
